### PR TITLE
Normalize staged files timestamps before creating zipapp

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,9 @@
             # Remove __pycache__ directories to keep the archive small.
             find "$staging" -type d -name "__pycache__" -prune -exec rm -rf {} +
 
+            epoch="${SOURCE_DATE_EPOCH:-315532800}"
+            find "$staging" -exec touch -h -d "@$epoch" {} +
+
             mkdir -p "$out/bin"
             (cd "$staging" && ${pythonExe} -m zipapp . \
               -m normalize_mp4.__main__:main \

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,8 @@
             cp -a "${ffmpegSite}/ffmpeg" "$staging/"
             cp -a "${ffmpegSite}"/ffmpeg_python-*.dist-info "$staging/"
 
+            chmod -R u+w "$staging"
+
             # Remove __pycache__ directories to keep the archive small.
             find "$staging" -type d -name "__pycache__" -prune -exec rm -rf {} +
 


### PR DESCRIPTION
## Summary
- touch all staged files to a 1980+ timestamp before running zipapp to avoid pre-1980 ZIP errors

## Testing
- Not run (nix unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc776ea4d8832cb88826f4dfc53145